### PR TITLE
Updated problem specific schemas with new fields in addition

### DIFF
--- a/src/schemas/tables/problem_type.sql
+++ b/src/schemas/tables/problem_type.sql
@@ -2,6 +2,8 @@ CREATE TABLE problem_type (
     id TEXT PRIMARY KEY DEFAULT UPPER(REPLACE(uuid_generate_v4()::TEXT, '-', '')),
     type_cd TEXT NOT NULL,
     type_desc TEXT NOT NULL,
+    executor TEXT NOT NULL,
+    core BOOLEAN DEFAULT FALSE,
     created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100) DEFAULT 'SYSTEM',
     modified_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/src/schemas/tables/support_language.sql
+++ b/src/schemas/tables/support_language.sql
@@ -3,6 +3,7 @@ CREATE TABLE support_language (
     type_id TEXT NOT NULL,
     lang_cd TEXT NOT NULL UNIQUE,
     language TEXT NOT NULL,
+    metadata TEXT,
     created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100) DEFAULT 'SYSTEM',
     modified_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/src/schemas/tables/tags.sql
+++ b/src/schemas/tables/tags.sql
@@ -2,6 +2,7 @@ CREATE TABLE tags (
     id TEXT PRIMARY KEY DEFAULT UPPER(REPLACE(uuid_generate_v4()::TEXT, '-', '')),
     tag_cd TEXT NOT NULL UNIQUE,
     tag_desc TEXT,
+    core BOOLEAN DEFAULT FALSE,
     created_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100) DEFAULT 'SYSTEM',
     modified_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
- Updated problem_type schema with executor field to store the type of the executor required for the problem and core field to enable the functionality of preventing deletion of mandatory tags.
- Updated support_language with metadata field to store some other information if required.
- Updated tags with core field to enable the functionality of preventing deletion of mandatory tags.